### PR TITLE
Multiple updates for Annual Assessment

### DIFF
--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -51,3 +51,6 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-02: Customer accounts will be deactivated after not logging into the system after 90 days.
+* 2021-11: Reviewed by @pburkholder, no changes
+

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -32,6 +32,8 @@ The cloud.gov Program Manager ensures that Cloud Operations staff with significa
 
 Whenever a new person joins the Cloud Operations team, the cloud.gov Program Manager assigns the team member a GitHub issue documenting a checklist of required training materials. The same process is applied to each team member annually as if they were a new team member.
 
+Training records for GSA-mandated training are kept for at least one year, cloud-gov specific records are kept for at least five years.
+
 See AT-3, AT-4.
 
 # Version history
@@ -42,3 +44,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: State retention policy for training records

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -38,7 +38,7 @@ All applications will partially inherit some of the ELK stack auditing functions
 Audit logs will be made available to client organizations and for mutual support in response to security breaches, system and user access, incident reporting and continuous monitoring.  Cloud Operations will generate and distribute audit reports, provide dashboard access for audited events, and send audit log data to SIEM and log analysis systems as needed.
 The cloud.gov Program Manager has established processes for regularly reviewing audit log information, and reporting security issues if discovered. Reviews will occur at a minimum of weekly and are integrated with processes for incident response, in order to ensure standardization and cross-functional collaboration. All alerts are investigated.
 
-cloud.gov uses CloudTrail, CloudWatch, and Riemann to integrate audit monitoring, analysis and reporting into an overall process for investigation and response to suspicious activities. In addition, the cloud.gov team employs PagerDuty as an automated mechanism to immediately alert security personnel of inappropriate or unusual activities that have security implications.
+cloud.gov uses CloudTrail, CloudWatch, Prometheus, and Grafana to integrate audit monitoring, analysis and reporting into an overall process for investigation and response to suspicious activities. In addition, the cloud.gov team employs PagerDuty as an automated mechanism to immediately alert security personnel of inappropriate or unusual activities that have security implications.
 As a result, all information within the system is available for audit and available for after the fact investigations.
 
 cloud.gov provides an audit trail that shows all actions that an operator has taken with the platform. For users, cloud.gov records an audit trail of all relevant API invocations of an application.
@@ -51,7 +51,7 @@ Cloud Operations updates the defined auditable events on a quarterly basis or wh
 
 See AU-2(3).
 
-CloudTrail, CloudWatch, Snort, Tripwire, Clam AV, and Riemann collect, monitor, and maintain audit logs for both AWS and cloud.gov.
+CloudTrail, CloudWatch, Snort, Tripwire, Clam AV, Prometheus and Grafana collect, monitor, and maintain audit logs for both AWS and cloud.gov.
 
 The events monitored include but are not limited to successful and unsuccessful account logon events, account management events, object access, policy change, privilege functions, process tracking, and system events for both AWS and cloud.gov. These events are tracked for all administrator activity, authentication checks, authorization checks, data deletions, data access, data changes, and permission changes.
 
@@ -80,7 +80,7 @@ The Cloud Operations team acts on findings that result from its regular audit pr
 
 See AU-6.
 
-cloud.gov uses the automated mechanisms CloudTrail, CloudWatch, and Riemann to integrate audit monitoring, analysis and reporting into an overall process for investigation and response to suspicious activities. Riemann receives data from multiple sources and makes that data available for regular auditing.
+cloud.gov uses the automated mechanisms CloudTrail, CloudWatch, and Grafana to integrate audit monitoring, analysis and reporting into an overall process for investigation and response to suspicious activities. Prometheus receives data from multiple sources and makes that data available for regular auditing.
 
 Cloud Operations employs automated CloudWatch logs to collect and track metrics to monitor in real time infrastructure log data and resources.
 
@@ -92,10 +92,10 @@ See AU-6(3).
 
 CloudWatch Logs provides on-demand audit review for any actions taken on or in the AWS environment.
 
-Riemann, InfluxDB, and Grafana provide the capability to evaluate any action taken on the cloud.gov layer.
+Prometheus and Grafana provide the capability to evaluate any action taken on the cloud.gov layer.
 
 The ELK stack, which captures logs related to applications hosted on top of cloud.gov, has the capability to provide audit reduction, analysis, and report generation capability. Specifically, Kibana has the capacity to build search queries on numerous criteria regarding application logs, and produce reports and exports.
-CloudWatch Logs, Riemann, InfluxDB, Grafana, and ELK do not alter the original content or time ordering of audit records. All audit files can be viewed in their raw and JSON standard formats.
+CloudWatch Logs, Prometheus, Grafana, and ELK do not alter the original content or time ordering of audit records. All audit files can be viewed in their raw and JSON standard formats.
 
 See AU-7.
 
@@ -127,7 +127,7 @@ Audit logs are kept according to NARA and GSA retention standards to provide sup
 
 See AU-11.
 
-cloud.gov provides comprehensive audit record generation capability for all components: CloudWatch Logs for AWS, metrics.fr.cloud.gov for cloud.gov metrics, and logs.fr.cloud.gov for applications on cloud.gov.
+cloud.gov provides comprehensive audit record generation capability for all components: CloudWatch Logs for AWS, grafana.fr.cloud.gov for cloud.gov metrics, and logs.fr.cloud.gov for applications on cloud.gov.
 
 Cloud Operations are responsible for maintaining the configuration that enforces the audit settings.
 Cloud Operations team members select which auditable events are to be audited by specific components of cloud.gov where audit capability is deployed.
@@ -142,3 +142,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Update to reference Grafana and Prometheus instead of obsoleted components

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -33,9 +33,13 @@ The main assessment procedures used are the [Federal Risk and Authorization Mana
 
 Assessments of 18F operations are performed in tandem with vulnerability scanning, malicious user testing, insider threat assessments, and other tests regularly conducted by the following teams: the cloud.gov team, TTS Technology Portfolio, GSA Information Security, and a 3PAO. The system is also under continuous monitoring from cloud.gov's Cloud Operations team.
 
-18F takes any results seriously, and it implements remediations as soon as possible. Plans of action and milestones (POAMs) are maintained to ensure any findings are resolved, compensated for, or accepted as an operational requirement.
+18F takes any results seriously, and it remediates issues as soon as possible. Plans of action and milestones (POA&Ms) are maintained to ensure any findings are resolved, compensated for, or accepted as an operational requirement.
 
 See CA-2, CA-2(1), CA-2(2), CA-2(3), CA-5, CA-7, CA-7(1), CA-8, CA-8(1).
+
+The cloud.gov system does not establish any direct connections to external system. Network connections are on a deny-all, permit-by-exception basis. 
+
+See CA-3, CA-3(3), CA-3(5)
 
 The FedRAMP JAB through the program management office (PMO) is the Authorizing Official (AO) for cloud.gov.
 
@@ -49,3 +53,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Fix "remediations", clarify no direct connect, permit-by-exception

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -27,13 +27,13 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-As a cloud service provider that is also part of the General Services Agency (GSA), a federal agency, 18F ensures cloud.gov invests in comprehensive risk management assessments.
+As a cloud service provider that is also part of the General Services Agency (GSA), a federal agency, GSA TTS ensures cloud.gov invests in comprehensive risk management assessments.
 
-The main assessment procedures used are the [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fedramp.gov/). Further, 18F engages an [accredited third-party assessment organization](https://www.a2la.org/accreditation/fedramp) (3PAO) to provide an independent review of the cloud.gov system and organizational operations.
+The main assessment procedures used are the [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fedramp.gov/). Further, GSA TTS engages an [accredited third-party assessment organization](https://www.a2la.org/accreditation/fedramp) (3PAO) to provide an independent review of the cloud.gov system and organizational operations.
 
-Assessments of 18F operations are performed in tandem with vulnerability scanning, malicious user testing, insider threat assessments, and other tests regularly conducted by the following teams: the cloud.gov team, TTS Technology Portfolio, GSA Information Security, and a 3PAO. The system is also under continuous monitoring from cloud.gov's Cloud Operations team.
+Assessments of cloud.gov operations are performed in tandem with vulnerability scanning, malicious user testing, insider threat assessments, and other tests regularly conducted by the following teams: the cloud.gov team, TTS Technology Portfolio, GSA Information Security, and a 3PAO. The system is also under continuous monitoring from cloud.gov's Cloud Operations team.
 
-18F takes any results seriously, and it remediates issues as soon as possible. Plans of action and milestones (POA&Ms) are maintained to ensure any findings are resolved, compensated for, or accepted as an operational requirement.
+GSA TTS takes any results seriously, and it remediates issues as soon as possible. Plans of action and milestones (POA&Ms) are maintained to ensure any findings are resolved, compensated for, or accepted as an operational requirement.
 
 See CA-2, CA-2(1), CA-2(2), CA-2(3), CA-5, CA-7, CA-7(1), CA-8, CA-8(1).
 

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -35,7 +35,7 @@ See CM-9.
 
 Cloud Operations first provisions the initial infrastructure tool, Concourse (a continuous integration pipelining tool), into the desired "infrastructure as a service" account, using this [procedure](https://github.com/cloud-gov/cg-provision). Concourse then ensures that all configurations of further automated deployments are controlled, whether they are the result of running Terraform or BOSH.
 
-Cloud Operations encodes cloud.gov's infrastructure into a set of [Terraform](https://www.terraform.io) configuration files. Terraform files are checked into [18F's cloud.gov GitHub repositories](https://github.com/18F?utf8=%E2%9C%93&query=cg), and local git repositories, in order to ensure distributed version control and availability of the code.
+Cloud Operations encodes cloud.gov's infrastructure into a set of [Terraform](https://www.terraform.io) configuration files. Terraform files are checked into the [cloud.gov GitHub repositories](https://github.com/cloud-gov), and local git repositories, in order to ensure distributed version control and availability of the code.
 
 See CM-2, CM-2(2), CM-2(3), CM-6(1).
 
@@ -51,4 +51,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
-* 2021-11: Reviewed by @pburkholder, no changes
+* 2021-11: Correct GitHub to link to cloud-gov org

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -51,3 +51,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Reviewed by @pburkholder, no changes

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -40,3 +40,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Reviewed by @pburkholder, no changes

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -31,7 +31,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-The cloud.gov Program Manager organizes incident response training sessions, offered to the whole cloud.gov team at least annually, and requires that all Cloud Operations team members take the training. The training may be led by the Program Manager, a Cloud Operations team member, or another security specialist at 18F.
+The cloud.gov Program Manager organizes incident response training sessions, offered to the whole cloud.gov team at least annually, and requires that all Cloud Operations team members take the training. The training may be led by the Program Manager, a Cloud Operations team member, or another security specialist at GSA TTS.
 
 The cloud.gov team onboarding checklist (https://github.com/cloud-gov/cg-product/blob/master/OnboardingChecklist.md) requires that all team members take incident response training within 60 days of joining the team.
 
@@ -44,13 +44,13 @@ See IR-2.
 
 The cloud.gov team, as directed by the Program Manager, creates test plans and exercises in accordance to NIST 800-61, and presents these to the cloud.gov Authorizing Official for their approval.
 
-cloud.gov tests its incident response capabilities with an annual table top exercise. The test takes the form of a teleconference (GSA Google Hangout) meeting where a security specialist (such as the Program Manager, a Cloud Operations team member, or another security specialist from 18F) guides the Cloud Operations team through a role-playing exercise with a simulated potential security incident. The team takes notes throughout the test, and afterward the team discusses the test and identifies weaknesses to fix with additional training or process improvements. The team files and tracks improvements with GitHub issues.
+cloud.gov tests its incident response capabilities with an annual table top exercise. The test takes the form of a teleconference (GSA Google Hangout) meeting where a security specialist (such as the Program Manager, a Cloud Operations team member, or another security specialist from GSA TTS) guides the Cloud Operations team through a role-playing exercise with a simulated potential security incident. The team takes notes throughout the test, and afterward the team discusses the test and identifies weaknesses to fix with additional training or process improvements. The team files and tracks improvements with GitHub issues.
 
 See IR-3, IR-3 (2).
 
 cloud.gov implements automated processes to detect and analyze malicious activity within the platform. If these processes detect malicious activity, they automatically report the activity to the Cloud Operations team.
 
-cloud.gov has an Incident Response Guide (https://docs.cloud.gov/ops/security-ir/) that documents the procedures that staff should take in the case of an incident, as required by the 18F and GSA Incident Response Policy.
+cloud.gov has an Incident Response Guide (https://docs.cloud.gov/ops/security-ir/) that documents the procedures that staff should take in the case of an incident, as required by the GSA TTS and GSA Incident Response Policy.
 
 See IR-4, IR-5, IR-6.
 
@@ -68,7 +68,7 @@ cloud.gov customers can subscribe to StatusPage to automatically receive alerts 
 
 See IR-7, IR-7 (1).
 
-As part of 18F, the cloud.gov team has direct and cooperative relationships with the Infrastructure team and the GSA Information Security team.
+As part of GSA TTS, the cloud.gov team has direct and cooperative relationships with the Infrastructure team and the GSA Information Security team.
 Within GSA Information Security, the cloud.gov team also works directly with its assigned ISSO, whose responsibility during incident response events facilitates cooperative relationships between cloud.gov’s incident response capability and external providers of information system protection capability.
 
 GSA Information Security has direct relationships with other providers of federal incident response capability, inclusive of US-CERT.
@@ -85,7 +85,7 @@ See IR-8.
 
 The cloud.gov Incident Response directs cloud.gov team members to watch out for and immediately report any potential security incident, which includes reporting suspected information spills (such as sensitive or classified information in the wrong places). In the event of a suspected information spill, cloud.gov team members follow the reporting process in the cloud.gov Incident Response Guide.
 
-The 18F Open Source Policy practices guide (which cloud.gov follows as part of 18F) at https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information includes a reminder that spilled classified information must be reported via the response process.
+The GSA TTS handbook [section on protecting sensitive information](https://handbook.tts.gsa.gov/general-information-and-resources/sensitive-information/) includes a reminder that spilled (or leaked/exposed) sensitive information must be reported via the response process.
 
 The System Owner, Program Manager, and Cloud Operations team members have primary responsibility for implementing the actual response to security incidents, including technical measures. GSA Information Security is responsible for assisting the cloud.gov team in responding to security incidents.
 

--- a/MA-Policy.md
+++ b/MA-Policy.md
@@ -23,7 +23,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-Software maintenance on cloud.gov is accomplished via the procedures of [Configuration Management (CM)](https://github.com/cloud-gov/cg-compliance-docs/blob/master/CM-Policy.md) and [System and Services Acquisition (SA)](https://github.com/18F/compliance-docs/blob/master/SA-Policy.md). Please see those control families for details.
+Software maintenance on cloud.gov is accomplished via the procedures of [Configuration Management (CM)](https://github.com/cloud-gov/cg-compliance-docs/blob/master/CM-Policy.md) and [System and Services Acquisition (SA)](https://github.com/cloud-gov/compliance-docs/blob/master/SA-Policy.md). Please see those control families for details.
 
 
 # Version history
@@ -34,4 +34,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
-* 2021-11: Reviewed by @pburkholder, no changes
+* 2021-11: Fix one link to cloud-gov GitHub

--- a/MA-Policy.md
+++ b/MA-Policy.md
@@ -34,3 +34,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Reviewed by @pburkholder, no changes

--- a/MP-Policy.md
+++ b/MP-Policy.md
@@ -35,3 +35,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Reviewed by @pburkholder, no changes

--- a/PE-Policy.md
+++ b/PE-Policy.md
@@ -39,3 +39,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Reviewed by @pburkholder, no changes

--- a/PL-Policy.md
+++ b/PL-Policy.md
@@ -25,9 +25,9 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-Using the most current FedRAMP SSP template, 18F developed a system security plan which includes the cloud.gov PaaS and encompasses the cloud.gov applications. The security plan is developed in accordance with NIST Special Publication 800-18 R1 Guide of Developing Federal Information System Security Plans, as well as FedRAMP guidance. The System Security Plan:
+Using the most current FedRAMP SSP template, 18F developed, and GSA TTS maintains, a system security plan which includes the cloud.gov PaaS and encompasses the cloud.gov applications. The security plan is developed in accordance with NIST Special Publication 800-18 R1 Guide of Developing Federal Information System Security Plans, as well as FedRAMP guidance. The System Security Plan:
 
-1.	Is consistent with 18F enterprise cloud.gov architecture;
+1.	Is consistent with cloud.gov architecture;
 2.	Explicitly defines the authorization boundary for cloud.gov PaaS;
 3.	Describes the operational context of cloud.gov PaaS in terms of missions and business processes;
 4.	Provides the security category and impact level of cloud.gov including supporting rationale;
@@ -36,12 +36,12 @@ Using the most current FedRAMP SSP template, 18F developed a system security pla
 7.	Provides an overview of the security requirements for cloud.gov; and
 8.	Describes the security controls in place or planned for meeting those requirements including a rationale for the tailoring and supplementation decisions.
 
-18F distributes copies of the cloud.gov security plan and communicates subsequent changes to the plan to the cloud.gov System Owner, ISSO, ISSM, AO and other designated members within the 18F staff and agency.
-The Information Security Officer, in conjunction with key 18F management officials, reviews the cloud.gov SSP at least annually or whenever there is a significant change to the information system.
+GSA TTS distributes copies of the cloud.gov security plan and communicates subsequent changes to the plan to the cloud.gov System Owner, ISSO, ISSM, AO and other designated members within the GSA TTS staff and agency.
+The Information Security Officer, in conjunction with key GSA TTS management officials, reviews the cloud.gov SSP at least annually or whenever there is a significant change to the information system.
 The Information Security Officer updates the cloud.gov SSP to address changes to the platform and its network of operation or problems identified during plan implementation or security control assessments, and thereafter whenever a significant change occurs.
-The Information Security Officer protects the security plan from unauthorized modification by maintaining it as a write-access-controlled Google Doc or alternatively in a version-controlled documentation repository (https://github.com/cloud-gov/cg-compliance ) that can only be modified by designated members from 18F and the agency.
+The Information Security Officer protects the security plan from unauthorized modification by maintaining it as a write-access-controlled Google Doc or alternatively in a version-controlled documentation repository (https://github.com/cloud-gov/cg-compliance ) that can only be modified by designated members from GSA TTS and the agency.
 
-The cloud.gov team intentionally makes most of the system security plan publicly available as open source documents in 18F repositories (including https://github.com/cloud-gov/cg-compliance and https://github.com/cloud-gov/cg-compliance-docs ). We follow 18F’s Open Source Policy (https://github.com/18F/open-source-policy/blob/master/policy.md ): our non-sensitive work should be public and open source whenever possible. The cloud.gov team does not share sensitive information (such as PII that may be in the SSP) publicly, and follows 18F guidance around this point: https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information
+The cloud.gov team intentionally makes most of the system security plan publicly available as open source documents in GSA TTS repositories (including https://github.com/cloud-gov/cg-compliance and https://github.com/cloud-gov/cg-compliance-docs ). We follow GSA TTS’s Open Source Policy (https://github.com/18F/open-source-policy/blob/master/policy.md ): our non-sensitive work should be public and open source whenever possible. The cloud.gov team does not share sensitive information (such as PII that may be in the SSP) publicly, and follows GSA TTS guidance around this point: https://handbook.tts.gsa.gov/general-information-and-resources/sensitive-information/
 
 See PL-2.
 
@@ -49,7 +49,7 @@ The Cloud Operations team plans and coordinates security-related activities affe
 
 See PL-2 (3).
 
-All 18F staff members are required to sign an acknowledgment indicating that they have read, understand, and agree to abide by the GSA Rules of Behavior, before authorizing access to information and the information system.
+All GSA TTS staff members are required to sign an acknowledgment indicating that they have read, understand, and agree to abide by the GSA Rules of Behavior, before authorizing access to information and the information system.
 
 cloud.gov documentation provides a public list of Rules of Behavior for all cloud.gov account holders, available under “Using your account responsibly” on this page: https://docs.cloud.gov/getting-started/accounts/
 
@@ -57,18 +57,18 @@ When logging into the cloud.gov system, all cloud.gov account holders (internal 
 
 See PL-4 and PL-4 (1).
 
-The system implements a centralized security stack that can support multiple applications; ensuring adherence to NIST 800-53 controls and FISMA, as well as 18F and GSA Information Technology (IT) Security Policies. Information security architecture is integrated into the information system by addressing information system requirements throughout the SDLC process. The FedRAMP JAB provides feedback to the Cloud Operations team on the security architecture and the Cloud Operations team receives regular guidance from the JAB board.
+The system implements a centralized security stack that can support multiple applications; ensuring adherence to NIST 800-53 controls and FISMA, as well as GSA TTS and GSA Information Technology (IT) Security Policies. Information security architecture is integrated into the information system by addressing information system requirements throughout the SDLC process. The FedRAMP JAB provides feedback to the Cloud Operations team on the security architecture and the Cloud Operations team receives regular guidance from the JAB board.
 
 cloud.gov uses industry best practices and applies hardening security benchmarks to all virtual machine instances.  For perimeter protection, each subnet is assigned individual elastic network interface (ENI), so security groups can be applied to each of the interfaces; firewall rules are applied for isolated traffic between subnets.  This adds an additional layer of protection.
 
 The determining factors of Confidentiality, Integrity, and Availability of the cloud.gov system are its FIPS 199 information types, which are listed in Section 2 of its SSP. The resulting Security Categorization, FIPS 199 Moderate Impact, governs the cloud.gov security architecture, which NIST SP 800-27A defines as “A description of security principles and an overall approach for architecture complying with the principles that drive the system design.” The information security architectural approach is documented in the cloud.gov System Security Plan, which describes implementation of said principles.
 
-The cloud.gov platform leverages IaaS via Amazon Web Services, which received a FedRAMP ATO in June 21, 2016.  This allows the cloud.gov platform to inherit some security controls such as physical security and share responsibility of other controls such as media protection. For web applications the 18F Cloud Operations team ensures that a web vulnerability scanner (OWASP Zap) is run on a monthly basis. 18F web applications use industry best practices and federal hardening guidelines for web servers and application services like Java.
+The cloud.gov platform leverages IaaS via Amazon Web Services, which received a FedRAMP ATO in June 21, 2016.  This allows the cloud.gov platform to inherit some security controls such as physical security and share responsibility of other controls such as media protection. For web applications the GSA TTS Cloud Operations team ensures that a web vulnerability scanner (OWASP Zap) is run on a monthly basis. GSA TTS web applications use industry best practices and federal hardening guidelines for web servers and application services like Java.
 
 The cloud.gov ISSO, cloud.gov System Owner, and FedRAMP JAB review applicable security architectures prior to major implementations or security assessments. The cloud.gov ISSO(s) reviews and updates the information security architecture within the System Security Plan on an annual basis or when a significant change takes place to reflect updates in the enterprise architecture. Due to the dynamic and elastic nature of cloud computing, the operations team monitors real-time updates of its information security architecture using the AWS Management Console and other management tools.
 The cloud.gov operations team follows the risk management framework (RMF) which includes conducting annual risk assessments for its information systems and infrastructure. Any changes are then updated in systems security plans, plan of actions and milestones POAMs, security assessment reports (SAR).
 
-All changes to the cloud.gov platform are routed through the 18F Change Control process using the GitHub ticketing and tracking system which monitors changes including, but not limited to, ensuring that information security architecture changes are appropriately reflected in updates to system security plans (SSP), Cloud Operations team documentation and other security architecture-related documentation.
+All changes to the cloud.gov platform are routed through the GSA TTS Change Control process using the GitHub ticketing and tracking system which monitors changes including, but not limited to, ensuring that information security architecture changes are appropriately reflected in updates to system security plans (SSP), Cloud Operations team documentation and other security architecture-related documentation.
 
 
 The cloud.gov Program Manager ensures that planned aspects of the cloud.gov security architecture are reflected in organization procurements/acquisitions and captured within the appropriate controls of this System Security Plan (SSP). Planned architectural changes, once approved, are incorporated into the annual SSP update cycle.
@@ -85,3 +85,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Update links to TTS policy, and update organization name

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -52,7 +52,7 @@ See PS-7.
 
 Whenever Cloud Operations, or any other team or individual, discovers that any GSA, 18F, or cloud.gov information security policies or procedures have been violated, they must immediately follow the [cloud.gov incident notification procedures (which also notifies GSA Information Security teams)](https://docs.cloud.gov/ops/security-ir/) and notify the System Owner, information system Authorizing Official, and the individual's direct supervisor via GSA email, separately. All notifications must occur within 24 hours of detecting a policy or procedure violation.
 
-The System Owner is responsible for immediately terminating the individual's access to the information system. The System Owner is also responsible for coordinating a cross-divisional ["post-mortem"](https://github.com/cloud-gov/cg-postmortems) exercise and report within 5 business days of the incident. All post-mortem reports should include remediations to reduce the chance of, or prevent, similar incidents in the future. The report is sent to the information system's Authorizing Official.
+The System Owner is responsible for immediately terminating the individual's access to the information system. The System Owner is also responsible for coordinating a cross-divisional ["incident retrospective"](https://drive.google.com/drive/folders/0B58iDAWKmw_BSEtqcUFFQ041MHc) exercise and report within 5 business days of the incident. All post-mortem reports should include remediations to reduce the chance of, or prevent, similar incidents in the future. The report is sent to the information system's Authorizing Official.
 
 The Authorizing Official is responsible for reviewing the report and is solely responsible for recommending actions to the individual's direct supervisor. If the Authorizing Official is satisfied by the remediations purposed, and the time-lines for implementing the remediations, the Authorizing Official may allow the System Owner to re-enable the individual's access to the information system. Regardless if access is re-enabled, the Authorizing Official must provide a recommendation on further sanctions or action.
 
@@ -81,3 +81,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Rename post-mortem to inc. retro, and link to Google Drive.

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -25,7 +25,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-For personnel categorization, position risk designation is assigned by the GSA Office of Human Resources Management (OHRM), 18F Talent, and 18F Supervisors. We follow the methodology prescribed in the Office of Personnel Management’s (OPM) Federal Investigations Notice, No. 10-06. Risk designations are re-categorized whenever responsibilities change, the impact level of the system or the information in it changes, or at least once every three years.
+For personnel categorization, position risk designation is assigned by the GSA Office of Human Resources Management (OHRM), GSA TTS Talent, and GSA TTS Supervisors. We follow the methodology prescribed in the Office of Personnel Management’s (OPM) Federal Investigations Notice, No. 10-06. Risk designations are re-categorized whenever responsibilities change, the impact level of the system or the information in it changes, or at least once every three years.
 
 See PS-2.
 
@@ -33,15 +33,15 @@ For personnel screening, we use the OPM process.
 
 See PS-3.
 
-Review of ongoing operational need for current logical and physical access by individuals are initiated and facilitated by the System Owner and Program Manager. The cloud.gov System Owner or Program Manager modifies permissions granted to individuals to correspond any changes in the individual requirements. 18F notifies the cloud.gov System Owner or Program Manager within 5 days of a formal transfer action. The cloud.gov System Owner or Program Manager initiates the revoking process within the same day of an individual being transferred outside of the team.
+Review of ongoing operational need for current logical and physical access by individuals are initiated and facilitated by the System Owner and Program Manager. The cloud.gov System Owner or Program Manager modifies permissions granted to individuals to correspond any changes in the individual requirements. GSA TTS notifies the cloud.gov System Owner or Program Manager within 5 days of a formal transfer action. The cloud.gov System Owner or Program Manager initiates the revoking process within the same day of an individual being transferred outside of the team.
 
 Retrieval of all information system-related property which includes HDPS-12 cards, authentication tokens, mobile devices, laptops, etc. is a common control provided by GSA. cloud.gov revokes privileged access if an individual is reassigned or transferred outside of the team.
 
 See PS-5.
 
-Since cloud.gov is provided by a federal agency to other agencies, 18F/GSA signs standard US Treasury forms (7600A and 7600B) to create inter-agency agreements (IAAs) that allow other agencies to access and use cloud.gov. The 18F Agreements team develops agreement text with the GSA Office of General Counsel (OGC) to ensure the boilerplate of all cloud.gov access agreements meet all legal, regulatory, policy, and Executive Order requirements.
+Since cloud.gov is provided by a federal agency to other agencies, GSA TTS signs standard US Treasury forms (7600A and 7600B) to create inter-agency agreements (IAAs) that allow other agencies to access and use cloud.gov. The GSA TTS Agreements team develops agreement text with the GSA Office of General Counsel (OGC) to ensure the boilerplate of all cloud.gov access agreements meet all legal, regulatory, policy, and Executive Order requirements.
 
-The System Owner reviews all access agreements at least yearly, or upon request from 18F Agreements, GSA Information Security, or OGC. 18F/GSA requires that all agencies have an active, signed, and fully-funded agreement to maintain access and use of the system.
+The System Owner reviews all access agreements at least yearly, or upon request from GSA TTS Agreements, GSA Information Security, or OGC. GSA TTS requires that all agencies have an active, signed, and fully-funded agreement to maintain access and use of the system.
 
 See PS-6.
 
@@ -50,7 +50,7 @@ GSA enforces the same requirements on contractors that it does on staff, and con
 See PS-7.
 
 
-Whenever Cloud Operations, or any other team or individual, discovers that any GSA, 18F, or cloud.gov information security policies or procedures have been violated, they must immediately follow the [cloud.gov incident notification procedures (which also notifies GSA Information Security teams)](https://docs.cloud.gov/ops/security-ir/) and notify the System Owner, information system Authorizing Official, and the individual's direct supervisor via GSA email, separately. All notifications must occur within 24 hours of detecting a policy or procedure violation.
+Whenever Cloud Operations, or any other team or individual, discovers that any GSA, TTS or cloud.gov information security policies or procedures have been violated, they must immediately follow the [cloud.gov incident notification procedures (which also notifies GSA Information Security teams)](https://docs.cloud.gov/ops/security-ir/) and notify the System Owner, information system Authorizing Official, and the individual's direct supervisor via GSA email, separately. All notifications must occur within 24 hours of detecting a policy or procedure violation.
 
 The System Owner is responsible for immediately terminating the individual's access to the information system. The System Owner is also responsible for coordinating a cross-divisional ["incident retrospective"](https://drive.google.com/drive/folders/0B58iDAWKmw_BSEtqcUFFQ041MHc) exercise and report within 5 business days of the incident. All post-mortem reports should include remediations to reduce the chance of, or prevent, similar incidents in the future. The report is sent to the information system's Authorizing Official.
 
@@ -81,4 +81,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
-* 2021-11: Rename post-mortem to inc. retro, and link to Google Drive.
+* 2021-11: Rename post-mortem to inc. retro, and link to Google Drive, Fix org name

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -33,7 +33,7 @@ Initial security categorization is a collaborative and inter-disciplinary activi
 
 See RA-2, RA-3.
 
-Cloud Operations and GSA Information Security work together to scan all of relevant portions of the cloud.gov stack. This includes dynamic scanning of any controls the cloud.gov team is responsible for inside of AWS GovCloud, the operating system baseline of AWS EC2 instances, Cloud Foundry modules, 18F built modules, or any other open source software the team has instantiated within the environment to support cloud.gov. Static code analysis is also performed on the 18F built modules.
+Cloud Operations and GSA Information Security work together to scan all of relevant portions of the cloud.gov stack. This includes dynamic scanning of any controls the cloud.gov team is responsible for inside of AWS GovCloud, the operating system baseline of AWS EC2 instances, Cloud Foundry modules, GSA TTS built modules, or any other open source software the team has instantiated within the environment to support cloud.gov. Static code analysis is also performed on the GSA TTS built modules.
 
 Note that _customers_ of cloud.gov are responsible for conducting static code analysis on the baseline of the applications they are deploying into cloud.gov containers.
 
@@ -50,3 +50,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Correct to using GSA TTS as organization name

--- a/SA-Policy.md
+++ b/SA-Policy.md
@@ -25,15 +25,13 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-The cloud.gov program uses two-week planning sprints. Before each sprint, work is prioritized, inclusive of security needs.
-
-18F is part of the Technology Transformation Service (TTS) within GSA; cloud.gov and 18F coordinate with TTS and GSA leadership to appropriately plan for cloud.gov’s budget and staffing needs.
+The cloud.gov program uses two-week planning sprints. Before each sprint, work is prioritized, inclusive of security needs. The cloud.gov CSP is part of the Technology Transformation Service (TTS) within GSA; cloud.gov coordinates with TTS and GSA leadership to appropriately plan for cloud.gov’s budget and staffing needs.
 
 cloud.gov has also been filed and registered as a major IT investment through the Electronic Capital Planning Investment Control (eCPIC) process with the Office of Management and Budget. As such, it is required to file reports on spending/budget with OMB. These reports include a breakout of spending on cloud.gov’s security analysis.
 
 See SA-2.
 
-18F practices a Scrumban process when developing new features or fixing existing issues, including security fixes and enhancements for cloud.gov.  Each feature or issue is assigned to a card in the system, where it goes through a process of being identified, prioritized, explored, delivered, and finally demonstrated. Each card is reviewed by the team as a whole throughout its lifecycle to identify any security risks or concerns, which are recorded on the card as "acceptance criteria" that must be addressed before development is complete.
+cloud.gov practices a Scrumban process when developing new features or fixing existing issues, including security fixes and enhancements for cloud.gov.  Each feature or issue is assigned to a card in the system, where it goes through a process of being identified, prioritized, explored, delivered, and finally demonstrated. Each card is reviewed by the team as a whole throughout its lifecycle to identify any security risks or concerns, which are recorded on the card as "acceptance criteria" that must be addressed before development is complete.
 
 Once development is complete, a team member submits the code to the version control system as a "pull request", where at least one other team member further reviews it before merging it into the code base.  New features are deployed into our staging area where they undergo further security review and stakeholder acceptance testing, as well as automated acceptance tests.
 The System Owner is responsible for ensuring appropriate staffing for security needs. The Cloud Operations team implements, configures, and maintains security controls.
@@ -55,7 +53,7 @@ cloud.gov itself does not accept personal identity verification (PIV) cards. Cus
 See SA-4 (10).
 
 Cloud Operations always obtains complete documentation, including administrator and user documentation, for any technology that is used within cloud.gov. The maintenance of administrator- and user- facing documentation, in the form of version-controlled changes in a code repository or our documentation repository, is an assumed requirement for all changes. Currently, cloud.gov only uses technology whose documentation can be shared publicly.
-18F values transparency and collaboration. All documentation for technologies used by cloud.gov is either linked to directly from https://docs.cloud.gov, or is shared broadly within GSA via Google Apps for Government.
+GSA TTS values transparency and collaboration. All documentation for technologies used by cloud.gov is either linked to directly from https://docs.cloud.gov, or is shared broadly within GSA via Google Apps for Government.
 
 See SA-5.
 
@@ -67,17 +65,17 @@ cloud.gov applies security best practices, including but not limited to:
 4.	Implementing role-based access controls, applying and enforcing permissions to isolate user to their space.  Baseline configurations settings are reviewed on a continual basis to comply with federal mandates and compliance standards.
 5.	Documenting changes to the baseline configuration in GitHub for review. Part of this process includes a thorough security analysis of the proposed change prior to the configuration change being implemented on the operational system.
 6.	Deploying with every application a standard set of tools for security and monitoring of each application to identify security issues.
-For more details please refer to the 18F Configuration Management Policy and security controls CM-2, CM-3, and CM-6.
+For more details please refer to the cloud.gov Configuration Management Policy and security controls CM-2, CM-3, and CM-6.
 
 See SA-8.
 
 The Authorizing Official is ultimately accountable for ensuring oversight and compliance in the use of external information systems, and reviews the addition of any external information system with the System Owner and GSA Information Security. The Authorizing Official also accepts the risk of operating any external information system that has not been assessed to a FedRAMP Security Controls Baseline.
 The Authorizing Official, System Owner, and GSA Information Security work together to ensure external information systems meet this control where applicable. See the GSA IT Standards Profile and the GSA IT Information Security Policy for additional information.
-18F uses its own monitoring program, or FedRAMP Continuous Monitoring program for external services.
+cloud.gov uses its own monitoring program, or FedRAMP Continuous Monitoring program for external services.
 
 See SA-9.
 
-18F always conducts risk assessments for all technologies and services. See the risk assessment (RA) procedures for details. If a planned change includes integrating a new external service (a service outside the cloud.gov FedRAMP authorization boundary) or changing an external service configuration/usage in a way that may have a security/compliance impact, the cloud.gov Authorizing Official is advised and asked to approve the plan.
+cloud.gov always conducts risk assessments for all technologies and services. See the risk assessment (RA) procedures for details. If a planned change includes integrating a new external service (a service outside the cloud.gov FedRAMP authorization boundary) or changing an external service configuration/usage in a way that may have a security/compliance impact, the cloud.gov Authorizing Official is advised and asked to approve the plan.
 
 See SA-9 (1).
 
@@ -116,7 +114,7 @@ is in progress and will complete in FY2022.
 
 See SA-11 (1).
 
-cloud.gov commonly incorporates open source code where the author cannot be held responsible for dynamic scanning. In such cases, 18F takes on responsibility for dynamic scanning. Nessus is the primary tool used for performing dynamic analysis.
+cloud.gov commonly incorporates open source code where the author cannot be held responsible for dynamic scanning. In such cases, cloud.gov takes on responsibility for dynamic scanning. Nessus is the primary tool used for performing dynamic analysis.
 
 See SA-11 (8).
 
@@ -129,4 +127,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
-* 2021-11: Clarify SA-11, code scanning
+* 2021-11: Clarify SA-11, code scanning, fix references to 18F

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -43,7 +43,7 @@ See SI-2, SI-2 (2), SI-2 (3).
 
 cloud.gov employs tools at information system entry and exit points to detect and eradicate malicious code with real-time scans, with virus definitions updated hourly. These send alerts to the Cloud Operations team if malicious code is detected. The Cloud Operations team follows the [Security Incident Response Guide](https://cloud.gov/docs/ops/security-ir/) upon detection of any potential security incident.
 
-All 18F-developed open source code that is used in the cloud.gov system is scanned using static analysis tools. When anyone proposes a change to the code (a pull request), the static analysis tool automatically runs and displays results.
+All GSA TTS-developed open source code that is used in the cloud.gov system is scanned using static analysis tools. When anyone proposes a change to the code (a pull request), the static analysis tool automatically runs and displays results.
 
 See SI-3, SI-3 (1), SC-3 (2), SC-3 (7).
 
@@ -75,3 +75,4 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2017-09: Security policy link updates
 * 2019-12: Update links to GSA security policy
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
+* 2021-11: Correct org name to GSA TTS


### PR DESCRIPTION
## Changes proposed in this pull request:

- AC: updated Version History to note 2021-02 change
- AT: State retention policy for training records
- AU: Update to reference Grafana and Prometheus instead of obsoleted components
- CA: Fix "remediations", clarify no direct connect, permit-by-exception
- PS: Rename post-mortem to inc. retro, and link to Google Drive.
- All others: Reviewed by @pburkholder, no changes

## Security considerations
Already open-source. Brings policies up to date with links and emerging practice.
