### PR TITLE
Merge TTS common control policies into PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *pdf
+_tmp.md

--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -1,3 +1,4 @@
+<!-- changequote(`{{', `}}') -->
 # Access control policy
 
 See [CIO 2100.1L – GSA IT Security Policy](https://www.gsa.gov/cdnstatic/CIO_2100_1L_CHGE_1_CC040905_signed_PDF_version_7-15-2019.pdf)
@@ -22,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 ## Policy overlay
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
+
+include({{TTS-Common-Control-Policy.md}})
+---
 
 ## Procedures
 
@@ -53,4 +57,3 @@ Complete version history: https://github.com/cloud-gov/cg-compliance-docs/commit
 * 2020-11: Update links to GitHub and GSA policies, split controls by CSF, add version history
 * 2021-02: Customer accounts will be deactivated after not logging into the system after 90 days.
 * 2021-11: Reviewed by @pburkholder, no changes
-

--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -1,4 +1,3 @@
-<!-- changequote(`{{', `}}') -->
 # Access control policy
 
 See [CIO 2100.1L – GSA IT Security Policy](https://www.gsa.gov/cdnstatic/CIO_2100_1L_CHGE_1_CC040905_signed_PDF_version_7-15-2019.pdf)
@@ -24,6 +23,7 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
 

--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -27,7 +27,7 @@ For information on roles and responsibilities, management commitment, coordinati
 include({{TTS-Common-Control-Policy.md}})
 ---
 
-## Procedures
+# Procedures
 
 cloud.gov's access control procedures starts with an offer letter to an individual from the GSA Office of Human Resources Management (OHRM). As the individual is on-boarded to the federal government, their personal information is recorded, biometrics are taken, preexisting identification is validated, and finally a personal identity verification (PIV) card is issued in full accordance with  Homeland Security Presidential Directive 12 (HSPD-12).
 

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -25,7 +25,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 If cloud.gov staff fail to comply with GSA security training requirements, their access to all GSA information systems is terminated. This includes access to cloud.gov systems.
 

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -22,6 +22,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 If cloud.gov staff fail to comply with GSA security training requirements, their access to all GSA information systems is terminated. This includes access to cloud.gov systems.

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -28,7 +28,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Cloud Operations has implemented CloudTrail and CloudWatch for its account and system monitoring of AWS virtual infrastructure. These tools provide visibility into user activity by recording API calls made on an AWS account and its cloud infrastructure. CloudTrail captures and records important information about each API call for the list of auditable events.
 

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -25,6 +25,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Cloud Operations has implemented CloudTrail and CloudWatch for its account and system monitoring of AWS virtual infrastructure. These tools provide visibility into user activity by recording API calls made on an AWS account and its cloud infrastructure. CloudTrail captures and records important information about each API call for the list of auditable events.

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -25,7 +25,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-## Procedures
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
+# Procedures
 
 As a cloud service provider that is also part of the General Services Agency (GSA), a federal agency, GSA TTS ensures cloud.gov invests in comprehensive risk management assessments.
 

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -26,7 +26,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 cloud.gov's specific configuration management procedures are packaged with the actual code of the cloud.gov system. Below is an overview of our procedures along with citations to controls and relevant GitHub repositories.
 

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -23,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 cloud.gov's specific configuration management procedures are packaged with the actual code of the cloud.gov system. Below is an overview of our procedures along with citations to controls and relevant GitHub repositories.

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -31,7 +31,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 See the [cloud.gov Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
 

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -28,6 +28,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 See the [cloud.gov Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).

--- a/IA-Policy.md
+++ b/IA-Policy.md
@@ -21,6 +21,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Identity and authentication in cloud.gov is entirely gated by cloud.gov's User Account and Authentication (UAA) Servers and their integration with GSA SecureAuth. Authentication to the underlying Amazon Web Service (AWS) is through the AWS Identity and Access Management (IAM).

--- a/IA-Policy.md
+++ b/IA-Policy.md
@@ -24,7 +24,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Identity and authentication in cloud.gov is entirely gated by cloud.gov's User Account and Authentication (UAA) Servers and their integration with GSA SecureAuth. Authentication to the underlying Amazon Web Service (AWS) is through the AWS Identity and Access Management (IAM).
 

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -32,7 +32,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 The cloud.gov Program Manager organizes incident response training sessions, offered to the whole cloud.gov team at least annually, and requires that all Cloud Operations team members take the training. The training may be led by the Program Manager, a Cloud Operations team member, or another security specialist at GSA TTS.
 

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -29,6 +29,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 The cloud.gov Program Manager organizes incident response training sessions, offered to the whole cloud.gov team at least annually, and requires that all Cloud Operations team members take the training. The training may be led by the Program Manager, a Cloud Operations team member, or another security specialist at GSA TTS.

--- a/MA-Policy.md
+++ b/MA-Policy.md
@@ -24,7 +24,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Software maintenance on cloud.gov is accomplished via the procedures of [Configuration Management (CM)](https://github.com/cloud-gov/cg-compliance-docs/blob/master/CM-Policy.md) and [System and Services Acquisition (SA)](https://github.com/cloud-gov/compliance-docs/blob/master/SA-Policy.md). Please see those control families for details.
 

--- a/MA-Policy.md
+++ b/MA-Policy.md
@@ -21,6 +21,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Software maintenance on cloud.gov is accomplished via the procedures of [Configuration Management (CM)](https://github.com/cloud-gov/cg-compliance-docs/blob/master/CM-Policy.md) and [System and Services Acquisition (SA)](https://github.com/cloud-gov/compliance-docs/blob/master/SA-Policy.md). Please see those control families for details.

--- a/MP-Policy.md
+++ b/MP-Policy.md
@@ -22,6 +22,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Not applicable.

--- a/MP-Policy.md
+++ b/MP-Policy.md
@@ -25,7 +25,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Not applicable.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
+MD_FILES=$(wildcard ??-Policy.md)
+PDF_FILES=$(patsubst %.md, %.pdf, $(MD_FILES))
+
+## all         : make all the PDFs
+.PHONY : all
+all: $(PDF_FILES)
+
+## pdf         : generate a single PDF
 %.pdf: %.md
 	m4 -I./ $< > _tmp.md
 	pandoc -o $@ _tmp.md -V colorlinks=true -V linkcolor=blue -V urlcolor=blue -V toccolor=gray
 	rm _tmp.md
 		
+## clean       : rm PDF and temp files
 clean:
 	rm *pdf *tmp.md
+
+## variables   : Print variables.
+.PHONY : variables
+variables:
+	@echo MD_FILES: $(MD_FILES)
+	@echo PDF_FILES: $(PDF_FILES)
+
+.PHONY : help
+help : Makefile
+	@sed -n 's/^##//p' $<
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+%.pdf: %.md
+	m4 -I./ $< > _tmp.md
+	pandoc -o $@ _tmp.md -V colorlinks=true -V linkcolor=blue -V urlcolor=blue -V toccolor=gray
+	rm _tmp.md
+		
+clean:
+	rm *pdf *tmp.md

--- a/PE-Policy.md
+++ b/PE-Policy.md
@@ -26,6 +26,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Not applicable.

--- a/PE-Policy.md
+++ b/PE-Policy.md
@@ -29,7 +29,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Not applicable.
 

--- a/PL-Policy.md
+++ b/PL-Policy.md
@@ -23,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Using the most current FedRAMP SSP template, 18F developed, and GSA TTS maintains, a system security plan which includes the cloud.gov PaaS and encompasses the cloud.gov applications. The security plan is developed in accordance with NIST Special Publication 800-18 R1 Guide of Developing Federal Information System Security Plans, as well as FedRAMP guidance. The System Security Plan:

--- a/PL-Policy.md
+++ b/PL-Policy.md
@@ -26,7 +26,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Using the most current FedRAMP SSP template, 18F developed, and GSA TTS maintains, a system security plan which includes the cloud.gov PaaS and encompasses the cloud.gov applications. The security plan is developed in accordance with NIST Special Publication 800-18 R1 Guide of Developing Federal Information System Security Plans, as well as FedRAMP guidance. The System Security Plan:
 

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -26,7 +26,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 For personnel categorization, position risk designation is assigned by the GSA Office of Human Resources Management (OHRM), GSA TTS Talent, and GSA TTS Supervisors. We follow the methodology prescribed in the Office of Personnel Management’s (OPM) Federal Investigations Notice, No. 10-06. Risk designations are re-categorized whenever responsibilities change, the impact level of the system or the information in it changes, or at least once every three years.
 

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -23,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 For personnel categorization, position risk designation is assigned by the GSA Office of Human Resources Management (OHRM), GSA TTS Talent, and GSA TTS Supervisors. We follow the methodology prescribed in the Office of Personnel Management’s (OPM) Federal Investigations Notice, No. 10-06. Risk designations are re-categorized whenever responsibilities change, the impact level of the system or the information in it changes, or at least once every three years.

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -28,7 +28,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 All GSA teams, being part of a federal agency, follow the risk assessment and management process outlined in [NIST Special Publication (SP) 800-37](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-37r1.pdf), _Guide for Applying the Risk Management Framework to Federal Information Systems_.
 

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -25,6 +25,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 All GSA teams, being part of a federal agency, follow the risk assessment and management process outlined in [NIST Special Publication (SP) 800-37](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-37r1.pdf), _Guide for Applying the Risk Management Framework to Federal Information Systems_.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,11 @@ For cloud.gov compliance documentation, see: https://github.com/cloud-gov/cg-com
 
 This is a public repository following [18F's Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md). See our [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) files for additional information.
 
-To generate PDFs of all the Markdown file, install `pandoc` (e.g. 
-`brew install pandoc`) , then:
+To generate PDFs of all the Markdown files, install `pandoc` (e.g. 
+`brew install pandoc`), then:
 
 ```shell
-for markdown  in *Policy.md
-do
-  pdf=$(echo $markdown | sed -e 's/md/pdf/')
-  echo == converting $markdown to $pdf ==
-  pandoc $markdown -s -o $pdf
-done
+make all
 ```
 
 ## Public domain

--- a/SA-Policy.md
+++ b/SA-Policy.md
@@ -23,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 The cloud.gov program uses two-week planning sprints. Before each sprint, work is prioritized, inclusive of security needs. The cloud.gov CSP is part of the Technology Transformation Service (TTS) within GSA; cloud.gov coordinates with TTS and GSA leadership to appropriately plan for cloud.gov’s budget and staffing needs.

--- a/SA-Policy.md
+++ b/SA-Policy.md
@@ -26,7 +26,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 The cloud.gov program uses two-week planning sprints. Before each sprint, work is prioritized, inclusive of security needs. The cloud.gov CSP is part of the Technology Transformation Service (TTS) within GSA; cloud.gov coordinates with TTS and GSA leadership to appropriately plan for cloud.gov’s budget and staffing needs.
 

--- a/SC-Policy.md
+++ b/SC-Policy.md
@@ -23,6 +23,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 Only privileged cloud.gov team roles (such as System Owner and Cloud Operations) have privileged Cloud Foundry API access, granted via User Account and Authentication (UAA) Server group membership. The cloud.gov team manages information system functionality surrounding and supporting the Cloud Foundry components via AWS, GitHub, and Concourse. Users do not get access to these facilities.

--- a/SC-Policy.md
+++ b/SC-Policy.md
@@ -26,7 +26,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 Only privileged cloud.gov team roles (such as System Owner and Cloud Operations) have privileged Cloud Foundry API access, granted via User Account and Authentication (UAA) Server group membership. The cloud.gov team manages information system functionality surrounding and supporting the Cloud Foundry components via AWS, GitHub, and Concourse. Users do not get access to these facilities.
 

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -28,7 +28,7 @@ For information on roles and responsibilities, management commitment, coordinati
 <!-- changequote(`{{', `}}') -->
 include({{TTS-Common-Control-Policy.md}})
 ---
-## Procedures
+# Procedures
 
 The cloud.gov team identifies cloud.gov system flaws, tracks and reports them, and corrects them.
 

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -25,6 +25,9 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
+<!-- changequote(`{{', `}}') -->
+include({{TTS-Common-Control-Policy.md}})
+---
 ## Procedures
 
 The cloud.gov team identifies cloud.gov system flaws, tracks and reports them, and corrects them.


### PR DESCRIPTION
## Changes proposed in this pull request:

- For assessments, we need the TTS common controls actually present in the full policy
- 
- 

## Security considerations
Adding M4 as a preprocessor is minimal risk. 

See example output
[AC-Policy.pdf](https://github.com/cloud-gov/cg-compliance-docs/files/7672119/AC-Policy.pdf)

