### PR TITLE
Procedure updates for breakglass, fix including TTS common to be prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *pdf
 _tmp.md
+tmp*md
+bq_tts.md

--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -28,8 +28,6 @@ changequote(`{{', `}}')
 include({{bq_tts.md}})
 x -->
 
----
-
 # Procedures
 
 cloud.gov's access control procedures starts with an offer letter to an individual from the GSA Office of Human Resources Management (OHRM). As the individual is on-boarded to the federal government, their personal information is recorded, biometrics are taken, preexisting identification is validated, and finally a personal identity verification (PIV) card is issued in full accordance with  Homeland Security Presidential Directive 12 (HSPD-12).

--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -23,10 +23,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-<!-- 
-include({{TTS-Common-Control-Policy.md}}) 
---> 
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
 
 ---
 
@@ -64,6 +64,14 @@ See SSP controls AC-2, AC-2(1), AC-2(2), AC-2(3), AC-2(4), AC-2(5), AC-2(7), AC-
 cloud.gov's customers gain access to the system in a similar fashion. The Client UAA Server can integrate with any enterprise identity system that supports the Security Assertion Markup Language (SAML) standard. Cloud Operations and the customer follow a simple procedure (https://cloud.gov/docs/ops/federated-identity/) in order to complete the integration. For cloud.gov customers using the cloud.gov identity provider, customer accounts will be deactivated after not logging into the system after 90 days.
 
 See SSP controls AC-2(9), AC-2(10), AC-21.
+
+The cloud.gov infrastructure service does have an emergency fallback
+"breakglass" account with keys that are kept in secure storage. Any
+use of the breakglass credentials generates alerts to Cloud Operations. We
+have code to rotate those credentials on-demand.
+
+See SSP controls AC-2(1)
+
 
 Within cloud.gov, both the permissions of users (whether internal or external) and the logical flow of data through the system is tightly controlled and regulated. Manual movements of data are strictly prohibited. Everything is subject to the virtual network, application, and container restrictions that are instantiated through cloud.gov's adherence to immutable "infrastructure as code."
 

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -22,8 +22,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -24,9 +24,9 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
----
+
 # Procedures
 
 If cloud.gov staff fail to comply with GSA security training requirements, their access to all GSA information systems is terminated. This includes access to cloud.gov systems.

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -27,9 +27,9 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
----
+
 
 # Procedures
 

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -25,9 +25,12 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
+
 # Procedures
 
 Our audit procedures ensure we gather events to assess our security posture,

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -27,9 +27,10 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
----
+
+
 # Procedures
 
 As a cloud service provider that is also part of the General Services Agency (GSA), a federal agency, GSA TTS ensures cloud.gov invests in comprehensive risk management assessments.

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -25,8 +25,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -23,8 +23,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -25,9 +25,9 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
----
+
 # Procedures
 
 cloud.gov's specific configuration management procedures are packaged with the actual code of the cloud.gov system. Below is an overview of our procedures along with citations to controls and relevant GitHub repositories.

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -28,8 +28,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -30,7 +30,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
 ---
 # Procedures

--- a/IA-Policy.md
+++ b/IA-Policy.md
@@ -21,8 +21,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/IA-Policy.md
+++ b/IA-Policy.md
@@ -23,7 +23,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
 ---
 # Procedures

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -29,8 +29,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+<!-- x
+changequote(`{{', `}}') 
 include({{TTS-Common-Control-Policy.md}})
+x -->
 ---
 # Procedures
 

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -31,7 +31,7 @@ For information on roles and responsibilities, management commitment, coordinati
 
 <!-- x
 changequote(`{{', `}}') 
-include({{TTS-Common-Control-Policy.md}})
+include({{bq_tts.md}})
 x -->
 ---
 # Procedures

--- a/MA-Policy.md
+++ b/MA-Policy.md
@@ -21,9 +21,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 Software maintenance on cloud.gov is accomplished via the procedures of [Configuration Management (CM)](https://github.com/cloud-gov/cg-compliance-docs/blob/master/CM-Policy.md) and [System and Services Acquisition (SA)](https://github.com/cloud-gov/compliance-docs/blob/master/SA-Policy.md). Please see those control families for details.

--- a/MP-Policy.md
+++ b/MP-Policy.md
@@ -22,9 +22,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 Not applicable.

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,19 @@ PDF_FILES=$(patsubst %.md, %.pdf, $(MD_FILES))
 .PHONY : all
 all: $(PDF_FILES)
 
+## bq_tts.md   : generate the intermediate blockquoted TTS commmon policy
+bq_tts.md: TTS-Common-Control-Policy.md
+	cat $< | sed -e 's/^/> /' > $@
+
 ## pdf         : generate a single PDF
-%.pdf: %.md
-	m4 -I./ $< > _tmp.md
-	pandoc -o $@ _tmp.md -V colorlinks=true -V linkcolor=blue -V urlcolor=blue -V toccolor=gray
-	rm _tmp.md
+%.pdf: %.md bq_tts.md
+	m4 -I./ $< > tmp_$<
+	cat tmp_$< | sed -e 's/<!-- x//' -e 's/x -->//' | pandoc -o $@ -V colorlinks=true -V linkcolor=blue -V urlcolor=blue -V toccolor=gray
+#	rm tmp_$<.md
 		
 ## clean       : rm PDF and temp files
 clean:
-	rm *pdf *tmp.md
+	rm *pdf *tmp.md tmp*md
 
 ## variables   : Print variables.
 .PHONY : variables

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bq_tts.md: TTS-Common-Control-Policy.md
 		
 ## clean       : rm PDF and temp files
 clean:
-	rm *pdf *tmp.md tmp*md
+	rm -f *pdf *tmp.md tmp*md bq_tts.md
 
 ## variables   : Print variables.
 .PHONY : variables

--- a/PE-Policy.md
+++ b/PE-Policy.md
@@ -26,11 +26,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
---
-<!-- changequote(`{{', `}}') "ignore this line" -->
-include({{TTS-Common-Control-Policy.md}})
-
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
 
 # PE Procedures
 

--- a/PE-Policy.md
+++ b/PE-Policy.md
@@ -26,10 +26,13 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
+--
+<!-- changequote(`{{', `}}') "ignore this line" -->
 include({{TTS-Common-Control-Policy.md}})
+
 ---
-# Procedures
+
+# PE Procedures
 
 Not applicable.
 

--- a/PL-Policy.md
+++ b/PL-Policy.md
@@ -23,9 +23,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 Using the most current FedRAMP SSP template, 18F developed, and GSA TTS maintains, a system security plan which includes the cloud.gov PaaS and encompasses the cloud.gov applications. The security plan is developed in accordance with NIST Special Publication 800-18 R1 Guide of Developing Federal Information System Security Plans, as well as FedRAMP guidance. The System Security Plan:

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -23,9 +23,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 For personnel categorization, position risk designation is assigned by the GSA Office of Human Resources Management (OHRM), GSA TTS Talent, and GSA TTS Supervisors. We follow the methodology prescribed in the Office of Personnel Management’s (OPM) Federal Investigations Notice, No. 10-06. Risk designations are re-categorized whenever responsibilities change, the impact level of the system or the information in it changes, or at least once every three years.

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -25,9 +25,10 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
 # Procedures
 
 All GSA teams, being part of a federal agency, follow the risk assessment and management process outlined in [NIST Special Publication (SP) 800-37](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-37r1.pdf), _Guide for Applying the Risk Management Framework to Federal Information Systems_.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,32 @@ For cloud.gov compliance documentation, see: https://github.com/cloud-gov/cg-com
 
 This is a public repository following [18F's Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md). See our [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) files for additional information.
 
+## Generating PDFs for assessors
+
 To generate PDFs of all the Markdown files, install `pandoc` (e.g. 
 `brew install pandoc`), and `basictex` (e.g. `brew install basictex`) then:
 
 ```shell
 make all
 ```
+
+## Editing documents
+
+We've created the `...Policy.md` documents to all include the file, `TTS-Common-Control-Policy.md`. 
+As Markdown in GitHub, that's simply a linked URL. To generate PDFs, we use the `m4`
+commands `changequote` and `include` to make an intermediate tmp file, then pipe that
+through to `sed` and `pandoc` to strip the "magic" comments and generate the final
+output.
+
+In short, maintain the following snippet in the input files to include the TTS common
+controls:
+
+    <!-- x
+    changequote(`{{', `}}') 
+    include({{bq_tts.md}})
+    x -->
+
+(The `changequote` is superfluous, we could just do ``include(`bq_tts.md')``)
 
 ## Public domain
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For cloud.gov compliance documentation, see: https://github.com/cloud-gov/cg-com
 This is a public repository following [18F's Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md). See our [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) files for additional information.
 
 To generate PDFs of all the Markdown files, install `pandoc` (e.g. 
-`brew install pandoc`), then:
+`brew install pandoc`), and `basictex` (e.g. `brew install basictex`) then:
 
 ```shell
 make all

--- a/SA-Policy.md
+++ b/SA-Policy.md
@@ -23,9 +23,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 The cloud.gov program uses two-week planning sprints. Before each sprint, work is prioritized, inclusive of security needs. The cloud.gov CSP is part of the Technology Transformation Service (TTS) within GSA; cloud.gov coordinates with TTS and GSA leadership to appropriately plan for cloud.gov’s budget and staffing needs.

--- a/SC-Policy.md
+++ b/SC-Policy.md
@@ -23,9 +23,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 Only privileged cloud.gov team roles (such as System Owner and Cloud Operations) have privileged Cloud Foundry API access, granted via User Account and Authentication (UAA) Server group membership. The cloud.gov team manages information system functionality surrounding and supporting the Cloud Foundry components via AWS, GitHub, and Concourse. Users do not get access to these facilities.

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -25,9 +25,11 @@ See the **_Applicability_** section of the GSA IT Security Policy.
 
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/cloud-gov/cg-compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-<!-- changequote(`{{', `}}') -->
-include({{TTS-Common-Control-Policy.md}})
----
+<!-- x
+changequote(`{{', `}}') 
+include({{bq_tts.md}})
+x -->
+
 # Procedures
 
 The cloud.gov team identifies cloud.gov system flaws, tracks and reports them, and corrects them.

--- a/TTS-Common-Control-Policy.md
+++ b/TTS-Common-Control-Policy.md
@@ -1,4 +1,3 @@
--->
 
 # TTS Common Control Policy
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update AC with breakglass AWS
- Make code changes that correspond to README update of:

We've created the `...Policy.md` documents to all include the file, `TTS-Common-Control-Policy.md`. 
As Markdown in GitHub, that's simply a linked URL. To generate PDFs, we use the `m4`
commands `changequote` and `include` to make an intermediate tmp file, then pipe that
through to `sed` and `pandoc` to strip the "magic" comments and generate the final
output.

In short, maintain the following snippet in the input files to include the TTS common
controls:

    <!-- x
    changequote(`{{', `}}') 
    include({{bq_tts.md}})
    x -->

- Makefile updates

## Security considerations

No operational considerations, no new information opsec info released
